### PR TITLE
Fix Matlab bindings in mparno:sigflex

### DIFF
--- a/MParT/MapFactory.h
+++ b/MParT/MapFactory.h
@@ -131,7 +131,7 @@ namespace mpart{
          * @param inputDim Dimension of the input space to component
          * @param offDiagOrder Maximum value of sum(alpha_{1:n-1}) when alpha_n=0. i.e., the total order of terms in the multiindex set that only contain nonzero values for off diagonal inputs.
          * @param crossOrder Maximum value of sum(alpha_{1:n-1}) terms when alpha_n>0. This parameter controls the complexity of interactions between off-diagonal components and the diagonal component.
-         * @param centers Set of centers of the sigmoids. Should be length 2 + (1 + 2 + ... + p) where p is the default total order.
+         * @param centers Set of centers of the sigmoids. Should be length \f$2 + (k_1 + k_2 + ... + k_L)\f$ where \f$L\f$ is the maximum order of the map component in the last input.
          * @param opts 
          * @return std::shared_ptr<ConditionalMapBase<MemorySpace>> 
          */

--- a/bindings/matlab/include/MexOptionsConversions.h
+++ b/bindings/matlab/include/MexOptionsConversions.h
@@ -11,7 +11,7 @@
 namespace mpart{
 namespace binding{
 
-    const unsigned int MPART_MEX_MAPOPTIONS_ARGCOUNT = 16;
+    const unsigned int MPART_MEX_MAPOPTIONS_ARGCOUNT = 17;
     const unsigned int MPART_MEX_TRAINOPTIONS_ARGCOUNT = 9;
 
     MapOptions MapOptionsFromMatlab(mexplus::InputArguments &input, int start);

--- a/bindings/matlab/include/MexOptionsConversions.h
+++ b/bindings/matlab/include/MexOptionsConversions.h
@@ -13,6 +13,7 @@ namespace binding{
 
     const unsigned int MPART_MEX_MAPOPTIONS_ARGCOUNT = 17;
     const unsigned int MPART_MEX_TRAINOPTIONS_ARGCOUNT = 9;
+    const unsigned int MPART_MEX_ATMOPTIONS_ARGCOUNT = MPART_MEX_MAPOPTIONS_ARGCOUNT + MPART_MEX_TRAINOPTIONS_ARGCOUNT + 3;
 
     MapOptions MapOptionsFromMatlab(mexplus::InputArguments &input, int start);
 

--- a/bindings/matlab/mat/ATMOptions.m
+++ b/bindings/matlab/mat/ATMOptions.m
@@ -15,19 +15,20 @@ classdef ATMOptions < TrainOptions & MapOptions
             obj.maxDegrees = value;
         end
         function optionsArray = getMexOptions(obj)
-            getMexOptions@MapOptions(obj);
-            optionsArray{16+1} = char(obj.opt_alg);
-            optionsArray{16+2} = obj.opt_stopval;
-            optionsArray{16+3} = obj.opt_ftol_rel;
-            optionsArray{16+4} = obj.opt_ftol_abs;
-            optionsArray{16+5} = obj.opt_xtol_rel;
-            optionsArray{16+6} = obj.opt_xtol_abs;
-            optionsArray{16+7} = obj.opt_maxeval;
-            optionsArray{16+8} = obj.opt_maxtime;
-            optionsArray{16+9} = obj.verbose;
-            optionsArray{16+9+1} = obj.maxPatience;
-            optionsArray{16+9+2} = obj.maxSize;
-            optionsArray{16+9+3} = obj.maxDegrees.get_id();
+            optionsArray = getMexOptions@MapOptions(obj);
+            num_MapOptions = length(optionsArray);
+            optionsArray{num_MapOptions+1} = char(obj.opt_alg);
+            optionsArray{num_MapOptions+2} = obj.opt_stopval;
+            optionsArray{num_MapOptions+3} = obj.opt_ftol_rel;
+            optionsArray{num_MapOptions+4} = obj.opt_ftol_abs;
+            optionsArray{num_MapOptions+5} = obj.opt_xtol_rel;
+            optionsArray{num_MapOptions+6} = obj.opt_xtol_abs;
+            optionsArray{num_MapOptions+7} = obj.opt_maxeval;
+            optionsArray{num_MapOptions+8} = obj.opt_maxtime;
+            optionsArray{num_MapOptions+9} = obj.verbose;
+            optionsArray{num_MapOptions+9+1} = obj.maxPatience;
+            optionsArray{num_MapOptions+9+2} = obj.maxSize;
+            optionsArray{num_MapOptions+9+3} = obj.maxDegrees.get_id();
         end
     end
 end

--- a/bindings/matlab/mat/MapOptions/MapOptions.m
+++ b/bindings/matlab/mat/MapOptions/MapOptions.m
@@ -2,8 +2,8 @@ classdef MapOptions
     properties (Access = public)
         basisType = BasisTypes.ProbabilistHermite;
         sigmoidType = SigmoidTypes.Logistic;
-        sigmoidBasisSumType = SigmoidSumSizeType.Linear;
         edgeType = EdgeTypes.SoftPlus;
+        sigmoidBasisSumType = SigmoidSumSizeType.Linear;
         posFuncType = PosFuncTypes.SoftPlus;
         quadType = QuadTypes.AdaptiveSimpson;
         quadAbsTol = 1e-6;
@@ -38,14 +38,11 @@ classdef MapOptions
         function obj = set.sigmoidType(obj,type)
             obj.sigmoidType = type;
         end
-        function obj = set.sigmoidBasisSumType(obj,type)
-            obj.sigmoidBasisSumType = type;
-        end
-        function obj = set.edgeShape(obj,value)
-            obj.edgeShape = value;
-        end
         function obj = set.edgeType(obj,value)
             obj.edgeType = value;
+        end
+        function obj = set.sigmoidBasisSumType(obj,type)
+            obj.sigmoidBasisSumType = type;
         end
         function obj = set.quadType(obj,type)
             obj.quadType = type;
@@ -62,6 +59,9 @@ classdef MapOptions
         function obj = set.quadMinSub(obj,value)
             obj.quadMinSub = value;
         end
+        function obj = set.edgeShape(obj,value)
+            obj.edgeShape = value;
+        end
         function obj = set.quadPts(obj,value)
             obj.quadPts = value;
         end
@@ -75,20 +75,20 @@ classdef MapOptions
             optionsArray{1} = char(obj.basisType);
             optionsArray{2} = char(obj.sigmoidType);
             optionsArray{3} = char(obj.edgeType);
-            optionsArray{4} = char(obj.posFuncType);
-            optionsArray{5} = char(obj.quadType);
-            optionsArray{6} = obj.quadAbsTol;
-            optionsArray{7} = obj.quadRelTol;
-            optionsArray{8} = obj.quadMaxSub;
-            optionsArray{9} = obj.quadMinSub;
-            optionsArray{10} = obj.edgeShape;
-            optionsArray{11} = obj.quadPts;
-            optionsArray{12} = obj.contDeriv;
-            optionsArray{13} = obj.basisLB;
-            optionsArray{14} = obj.basisUB;
-            optionsArray{15} = obj.basisNorm;
-            optionsArray{16} = obj.nugget;
-            optionsArray{17} = obj.sigmoidBasisSumType;
+            optionsArray{4} = char(obj.sigmoidBasisSumType);
+            optionsArray{5} = char(obj.posFuncType);
+            optionsArray{6} = char(obj.quadType);
+            optionsArray{7} = obj.quadAbsTol;
+            optionsArray{8} = obj.quadRelTol;
+            optionsArray{9} = obj.quadMaxSub;
+            optionsArray{10} = obj.quadMinSub;
+            optionsArray{11} = obj.edgeShape;
+            optionsArray{12} = obj.quadPts;
+            optionsArray{13} = obj.contDeriv;
+            optionsArray{14} = obj.basisLB;
+            optionsArray{15} = obj.basisUB;
+            optionsArray{16} = obj.basisNorm;
+            optionsArray{17} = obj.nugget;
         end
 
         function res = eq(obj1, obj2)
@@ -99,8 +99,8 @@ classdef MapOptions
             res = res && isequal(obj1.basisNorm,   obj2.basisNorm);
             res = res && isequal(obj1.posFuncType, obj2.posFuncType);
             res = res && isequal(obj1.sigmoidType, obj2.sigmoidType);
-            res = res && isequal(obj1.sigmoidBasisSumType, obj2.sigmoidBasisSumType);
             res = res && isequal(obj1.edgeType,    obj2.edgeType);
+            res = res && isequal(obj1.sigmoidBasisSumType, obj2.sigmoidBasisSumType);
             res = res && isequal(obj1.edgeShape,   obj2.edgeShape);
             res = res && isequal(obj1.quadType,    obj2.quadType);
             res = res && isequal(obj1.quadAbsTol,  obj2.quadAbsTol);
@@ -114,10 +114,10 @@ classdef MapOptions
 
         function Serialize(obj,filename)
             MParT_('MapOptions_Serialize',filename, char(obj.basisType),  ...
-            char(obj.sigmoidType), char(obj.edgeType), char(obj.posFuncType), char(obj.quadType), ...
+            char(obj.sigmoidType), char(obj.edgeType), char(obj.sigmoidBasisSumType), ...
+            char(obj.posFuncType), char(obj.quadType), ...
              obj.quadAbsTol, obj.quadRelTol, obj.quadMaxSub, obj.quadMinSub, obj.edgeShape, ...
-             obj.quadPts, obj.contDeriv, obj.basisLB, obj.basisUB, obj.basisNorm, obj.nugget,
-             char(obj.sigmoidBasisSumType))
+             obj.quadPts, obj.contDeriv, obj.basisLB, obj.basisUB, obj.basisNorm, obj.nugget)
         end
 
         function obj = Deserialize(obj,filename)
@@ -137,20 +137,20 @@ classdef MapOptions
             obj.basisType    = optionsArray{1};
             obj.sigmoidType  = optionsArray{2};
             obj.edgeType     = optionsArray{3};
-            obj.posFuncType  = optionsArray{4};
-            obj.quadType     = optionsArray{5};
-            obj.quadAbsTol   = optionsArray{6};
-            obj.quadRelTol   = optionsArray{7};
-            obj.quadMaxSub   = optionsArray{8};
-            obj.quadMinSub   = optionsArray{9};
-            obj.edgeShape    = optionsArray{10};
-            obj.quadPts      = optionsArray{11};
-            obj.contDeriv    = optionsArray{12};
-            obj.basisLB      = optionsArray{13};
-            obj.basisUB      = optionsArray{14};
-            obj.basisNorm    = optionsArray{15};
-            obj.nugget       = optionsArray{16};
-            obj.sigmoidBasisSumType = optionsArray{17};
+            obj.sigmoidBasisSumType = optionsArray{4};
+            obj.posFuncType  = optionsArray{5};
+            obj.quadType     = optionsArray{6};
+            obj.quadAbsTol   = optionsArray{7};
+            obj.quadRelTol   = optionsArray{8};
+            obj.quadMaxSub   = optionsArray{9};
+            obj.quadMinSub   = optionsArray{10};
+            obj.edgeShape    = optionsArray{11};
+            obj.quadPts      = optionsArray{12};
+            obj.contDeriv    = optionsArray{13};
+            obj.basisLB      = optionsArray{14};
+            obj.basisUB      = optionsArray{15};
+            obj.basisNorm    = optionsArray{16};
+            obj.nugget       = optionsArray{17};
         end
     end
 

--- a/bindings/matlab/src/ConditionalMap_mex.cpp
+++ b/bindings/matlab/src/ConditionalMap_mex.cpp
@@ -40,7 +40,7 @@ MEX_DEFINE(ConditionalMap_newTriMap) (int nlhs, mxArray* plhs[],
 MEX_DEFINE(ConditionalMap_TrainMapAdaptive) (int nlhs, mxArray* plhs[],
                                       int nrhs, const mxArray* prhs[]) {
 
-  InputArguments input(nrhs, prhs, 26);
+  InputArguments input(nrhs, prhs, 2+MPART_MEX_ATMOPTIONS_ARGCOUNT);
   OutputArguments output(nlhs, plhs, 1);
 
   std::vector<intptr_t> list_id_mset = input.get<std::vector<intptr_t>>(0);

--- a/bindings/matlab/src/MexOptionsConversions.cpp
+++ b/bindings/matlab/src/MexOptionsConversions.cpp
@@ -5,9 +5,9 @@ using namespace mpart;
 
 MapOptions MapOptionsFromMatlabArgs(
     std::string basisType, std::string sigmoidType,
-    std::string edgeType, std::string posFuncType,
-    std::string quadType, double quadAbsTol,
-    double quadRelTol, unsigned int quadMaxSub,
+    std::string edgeType, std::string sigmoidBasisSumType,
+    std::string posFuncType, std::string quadType,
+    double quadAbsTol, double quadRelTol, unsigned int quadMaxSub,
     unsigned int quadMinSub, double edgeShape,
     unsigned int quadPts, bool contDeriv, double basisLB,
     double basisUB, bool basisNorm, double nugget)
@@ -48,6 +48,14 @@ MapOptions MapOptionsFromMatlabArgs(
     std::cout << "Unknown sigmoidType, value is set to default" <<std::endl;
     }
 
+    if (sigmoidBasisSumType == "Linear") {
+        opts.sigmoidBasisSumType    = SigmoidSumSizeType::Linear;
+    } else if (sigmoidBasisSumType == "Constant") {
+        opts.sigmoidBasisSumType    = SigmoidSumSizeType::Constant;
+    } else {
+        std::cout << "Unknown sigmoidBasisSumType, value is set to default" <<std::endl;
+    }
+
     if (edgeType == "SoftPlus") {
     opts.edgeType    = EdgeTypes::SoftPlus;
     } else {
@@ -73,12 +81,13 @@ MapOptions mpart::binding::MapOptionsFromMatlab(mexplus::InputArguments &input, 
     return MapOptionsFromMatlabArgs(
         input.get<std::string>(start + 0), input.get<std::string>(start + 1),
         input.get<std::string>(start + 2), input.get<std::string>(start + 3),
-        input.get<std::string>(start + 4), input.get<double>(start + 5),
-        input.get<double>(start + 6), input.get<unsigned int>(start + 7),
-        input.get<unsigned int>(start + 8), input.get<double>(start + 9),
-        input.get<unsigned int>(start + 10), input.get<bool>(start + 11),
-        input.get<double>(start + 12), input.get<double>(start + 13),
-        input.get<bool>(start + 14), input.get<double>(start + 15)
+        input.get<std::string>(start + 4), input.get<std::string>(start + 5),
+        input.get<double>(start + 6), input.get<double>(start + 7),
+        input.get<unsigned int>(start + 8), input.get<unsigned int>(start + 9),
+        input.get<double>(start + 10), input.get<unsigned int>(start + 11),
+        input.get<bool>(start + 12), input.get<double>(start + 13),
+        input.get<double>(start + 14), input.get<bool>(start + 15),
+        input.get<double>(start + 16)
     );
 }
 
@@ -88,9 +97,11 @@ void mpart::binding::MapOptionsToMatlab(MapOptions opts, mexplus::OutputArgument
     output.set(i++, MapOptions::btypes[static_cast<unsigned int>(opts.basisType)]); // basisType
     output.set(i++, MapOptions::stypes[static_cast<unsigned int>(opts.sigmoidType)]); // sigmoidType
     output.set(i++, MapOptions::etypes[static_cast<unsigned int>(opts.edgeType)]); // edgeType
+    output.set(i++, MapOptions::sbstypes[static_cast<unsigned int>(opts.sigmoidBasisSumType)]); // sigmoidBasisSumType
     output.set(i++, MapOptions::pftypes[static_cast<unsigned int>(opts.posFuncType)]); // posFuncType
     output.set(i++, MapOptions::qtypes[static_cast<unsigned int>(opts.quadType)]); // quadType
-    
+
+    // Change if more scalars
     constexpr int numScalars = 10;
     // bools describe which are integers
     const std::pair<double,bool> optsScalars[numScalars] = {

--- a/bindings/matlab/tests/SigmoidTest.m
+++ b/bindings/matlab/tests/SigmoidTest.m
@@ -41,7 +41,7 @@ classdef SigmoidTest < matlab.unittest.TestCase
             opts = MapOptions;
             opts.basisType = BasisTypes.HermiteFunctions;
             comp = CreateSigmoidTriangular(input_dim, output_dim, max_order, centers_total, opts);
-            expected_coeffs = sum(arrayfun(@(d) (num_sigmoids+4)*nchoosek(d-1+max_order, input_dim-1), (input_dim-output_dim+1):input_dim));
+            expected_coeffs = sum(arrayfun(@(d) (num_sigmoids+4)*nchoosek(d-1+max_order, d-1), (input_dim-output_dim+1):input_dim));
             testCase.verifyEqual( comp.numCoeffs, uint32(expected_coeffs) );
         end
     end

--- a/src/MapFactory.cpp
+++ b/src/MapFactory.cpp
@@ -184,10 +184,6 @@ Sigmoid1d<MemorySpace, SigmoidType, EdgeType> CreateSigmoid(unsigned int inputDi
                                                             double edgeShape,
                                                             SigmoidSumSizeType sumType) 
 {
-    //Kokkos::View<double*, MemorySpace> widths("Sigmoid Widths", centers.size());
-    //Kokkos::View<double*, MemorySpace> weights("Sigmoid Weights", centers.size());
-
-
     int numSigmoids = Sigmoid1d<MemorySpace, SigmoidType, EdgeType>::ComputeNumSigmoids(centers.size(), sumType);
     
     // Fill vectors on host and then copy to device if necessary


### PR DESCRIPTION
Also some minor edits that are missed in the original PR. This has some issue with ATM unfortunately, but I'm also getting issues with ATM on main (albeit slightly different issues), so I'm not sure if this creates issues or not. Anyway, it's substantially correct.