### PR TITLE
Fixing matlab and Julia `CoeffBounds`

### DIFF
--- a/MParT/RectifiedMultivariateExpansion.h
+++ b/MParT/RectifiedMultivariateExpansion.h
@@ -393,7 +393,8 @@ namespace mpart{
                 
             // Fill in the lower bounds
             Kokkos::deep_copy(lb, -std::numeric_limits<double>::infinity());
-            Kokkos::parallel_for("lb loop", inds.extent(0), KOKKOS_LAMBDA (const int i) {
+            Kokkos::RangePolicy<ExecutionSpace> policy(0, inds.extent(0));
+            Kokkos::parallel_for("lb loop", policy, KOKKOS_LAMBDA (const int i) {
                 lb(inds(i)) = 0.0;
             });
 

--- a/bindings/julia/src/ConditionalMapBase.cpp
+++ b/bindings/julia/src/ConditionalMapBase.cpp
@@ -39,13 +39,13 @@ void mpart::binding::ConditionalMapBaseWrapper(jlcxx::Module &mod) {
             map.InverseImpl(JuliaToKokkos(x1), JuliaToKokkos(r), JuliaToKokkos(output));
             return output;
         })
-        .method("CoeffBounds", [](ConditionalMapBase<Kokkos::HostSpace> &map) {
-            jlcxx::ArrayRef<double> lb = jlMalloc<double>(map.numCoeffs);
-            jlcxx::ArrayRef<double> ub = jlMalloc<double>(map.numCoeffs);
-            Kokkos::View<double*, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>> lbview(&lb[0], lb.size());
-            Kokkos::View<double*, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>> ubview(&ub[0], ub.size());
+        .method("__CoeffBounds", [](ConditionalMapBase<Kokkos::HostSpace> &map) {
+            int numCoeffs = map.numCoeffs;
+            jlcxx::ArrayRef<double> bounds = jlMalloc<double>(2*numCoeffs);
+            Kokkos::View<double*, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>> lbview(&bounds[0], numCoeffs);
+            Kokkos::View<double*, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>> ubview(&bounds[numCoeffs], numCoeffs);
             map.FillCoeffBoundsImpl(lbview,ubview);
-            return std::make_pair(lb,ub);
+            return bounds;
         })
         ;
     jlcxx::stl::apply_stl<ConditionalMapBase<Kokkos::HostSpace>*>(mod);

--- a/bindings/matlab/mat/ConditionalMap.m
+++ b/bindings/matlab/mat/ConditionalMap.m
@@ -142,11 +142,11 @@ methods
   function result = CoeffMap(this)
     result = MParT_('ConditionalMap_CoeffMap',this.id_);
   end
-  
-  function result = CoeffBounds(this)
-    result = MParT_('ConditionalMap_CoeffBounds',this.id_);
-  end 
-  
+
+  function [lb, ub] = CoeffBounds(this)
+    [lb, ub] = MParT_('ConditionalMap_CoeffBounds',this.id_);
+  end
+
   function result = numCoeffs(this)
     result = MParT_('ConditionalMap_numCoeffs',this.id_);
   end

--- a/bindings/matlab/tests/ConditionalMapTest.m
+++ b/bindings/matlab/tests/ConditionalMapTest.m
@@ -1,0 +1,63 @@
+classdef ConditionalMapTest < matlab.unittest.TestCase
+    % Copyright 2014 - 2016 The MathWorks, Inc.
+
+    methods ( Test )
+
+        function TestNumCoeffs( testCase )
+            [component,~,~] = setup();
+            testCase.verifyEqual( component.numCoeffs, uint32(2) );
+        end
+
+        function TestCoeffMap( testCase )
+            [component,~,~] = setup();
+            component.SetCoeffs(zeros(1,component.numCoeffs));
+            testCase.verifyEqual( component.CoeffMap(), [0 0] );
+
+            coeffs = randn(1,component.numCoeffs);
+            component.SetCoeffs(coeffs);
+            testCase.verifyEqual( component.CoeffMap(), coeffs );
+        end
+
+        function TestCoeffBounds( testCase )
+            [component,~,~] = setup();
+            [lb, ub] = component.CoeffBounds();
+            testCase.verifyEqual( uint32(numel(lb)), component.numCoeffs );
+            testCase.verifyEqual( uint32(numel(ub)), component.numCoeffs );
+
+            testCase.verifyEqual( max(lb), -Inf );
+            testCase.verifyEqual( min(ub), Inf );
+        end
+
+        function TestEvaluate( testCase )
+            [component,num_samples,x] = setup();
+            testCase.verifyEqual( size(component.Evaluate(x)), [1,num_samples] );
+        end
+
+        function TestLogDeterminant( testCase )
+            [component,num_samples,x] = setup();
+            testCase.verifyEqual( size(component.LogDeterminant(x)), [num_samples,1] );
+        end
+
+        function TestInverse( testCase )
+            [component,num_samples,x] = setup();
+            coeffs = randn(component.numCoeffs,1);
+            component.SetCoeffs(coeffs);
+            y = component.Evaluate(x);
+            x_ = component.Inverse(zeros(1,num_samples),y);
+            testCase.verifyTrue( all( abs(x_ - x(end,:)) < 1E-3 ) );
+        end
+
+
+    end
+end
+
+function [component, num_samples, x] = setup()
+    opts = MapOptions();
+
+    multis = [0;1];  % linear
+    mset = MultiIndexSet(multis).Fix();
+
+    component = CreateComponent(mset, opts);
+    num_samples = 100;
+    x = randn(1,num_samples);
+end

--- a/bindings/matlab/tests/Test_TriangularMap.m
+++ b/bindings/matlab/tests/Test_TriangularMap.m
@@ -54,7 +54,7 @@ M3 = CreateTriangular(dim1+dim2+dim3,dim3,maxDegree,opts);
 
 triMap = TriangularMap([M1 M2 M3]);
 
-triMap.SetCoeffs(randn(dim,triMap.numCoeffs));
+triMap.SetCoeffs(randn(1,triMap.numCoeffs));
 
 disp(['Num coeffs triMap: ',num2str(triMap.numCoeffs)])
 disp(['Sum coeffs maps: ',num2str(M1.numCoeffs+M2.numCoeffs+M3.numCoeffs)])

--- a/src/ConditionalMapBase.cpp
+++ b/src/ConditionalMapBase.cpp
@@ -300,7 +300,9 @@ std::pair<Kokkos::View<double*,Kokkos::HostSpace>, Kokkos::View<double*,Kokkos::
     Kokkos::View<double*, MemorySpace> ub("upper bound",this->numCoeffs);
     
     FillCoeffBoundsImpl(lb,ub);
-    return std::make_pair(lb,ub);
+    Kokkos::View<double*,Kokkos::HostSpace> lb_h = Kokkos::mirror_view_and_copy(Kokkos::HostSpace(), lb);
+    Kokkos::View<double*,Kokkos::HostSpace> ub_h = Kokkos::mirror_view_and_copy(Kokkos::HostSpace(), ub);
+    return std::make_pair(lb_h,ub_h);
 }
 
 template<typename MemorySpace>

--- a/src/ConditionalMapBase.cpp
+++ b/src/ConditionalMapBase.cpp
@@ -296,13 +296,11 @@ Eigen::RowMatrixXd ConditionalMapBase<mpart::DeviceSpace>::LogDeterminantInputGr
 template<typename MemorySpace>
 std::pair<Kokkos::View<double*,Kokkos::HostSpace>, Kokkos::View<double*,Kokkos::HostSpace>> ConditionalMapBase<MemorySpace>::CoeffBounds() const
 {
-    Kokkos::View<double*, MemorySpace> lb("lower bound",this->numCoeffs);
-    Kokkos::View<double*, MemorySpace> ub("upper bound",this->numCoeffs);
+    Kokkos::View<double*, Kokkos::HostSpace> lb("lower bound",this->numCoeffs);
+    Kokkos::View<double*, Kokkos::HostSpace> ub("upper bound",this->numCoeffs);
     
     FillCoeffBoundsImpl(lb,ub);
-    Kokkos::View<double*,Kokkos::HostSpace> lb_h = Kokkos::mirror_view_and_copy(Kokkos::HostSpace(), lb);
-    Kokkos::View<double*,Kokkos::HostSpace> ub_h = Kokkos::mirror_view_and_copy(Kokkos::HostSpace(), ub);
-    return std::make_pair(lb_h,ub_h);
+    return std::make_pair(lb,ub);
 }
 
 template<typename MemorySpace>

--- a/src/MultiIndices/FixedMultiIndexSet.cpp
+++ b/src/MultiIndices/FixedMultiIndexSet.cpp
@@ -364,7 +364,8 @@ FixedMultiIndexSet<MemorySpace> FixedMultiIndexSet<MemorySpace>::Cartesian(Fixed
     Kokkos::View<unsigned int*, MemorySpace> newDims("nzDims", otherSize*nzDims.size() + thisSize*otherSet.nzDims.size());
     Kokkos::View<unsigned int*, MemorySpace> newOrders("nzOrders", otherSize*nzOrders.size() + thisSize*otherSet.nzOrders.size());
 
-    Kokkos::parallel_for("Dummy Loop", 1, KOKKOS_LAMBDA (const int blahind) {
+    Kokkos::RangePolicy<typename MemoryToExecution<MemorySpace>::Space> policy(0, 1);
+    Kokkos::parallel_for("Dummy Loop", policy, KOKKOS_CLASS_LAMBDA (const int blahind) {
         
         unsigned int currStart = 0;
         unsigned int thisNumNz, otherNumNz;
@@ -421,7 +422,8 @@ FixedMultiIndexSet<MemorySpace> FixedMultiIndexSet<MemorySpace>::Concatenate(Fix
 
     //  Starts stemming from other set
     Kokkos::View<unsigned int*, MemorySpace> otherStarts = otherSet.nzStarts;
-    Kokkos::parallel_for("Other Starts", otherSize+1, KOKKOS_LAMBDA (const int i) {
+    Kokkos::RangePolicy<typename MemoryToExecution<MemorySpace>::Space> policy(0, otherSize+1);
+    Kokkos::parallel_for("Other Starts", policy, KOKKOS_LAMBDA (const int i) {
         newStarts(thisSize+i) = thisNumNz + otherStarts(i);
     });
     


### PR DESCRIPTION
There's a sibling PR for the MParT.jl repo going up momentarily. This also adds tests in the Matlab unit testing framework for ConditionalMapBase (including CoeffBounds), introducing parity to the interface.